### PR TITLE
Revert HW accel due to video memory leak

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,9 @@
 qmlmatrix (4.0.0-0) unstable; urgency=low
 
   * Update dependencies for Stretch
-  * Use hardware acceleration for rendering
-  * Increase frame-rate to 40 fps.
+  * Increase frame-rate to 40 fps
 
- -- Team Kano <dev@kano.me>  Mon, 18 Jun 2018 12:21:00 +0100
+ -- Team Kano <dev@kano.me>  Fri, 22 Jun 2018 12:21:00 +0100
 
 qmlmatrix (1.0-1) unstable; urgency=low
 

--- a/resources/Matrix/matrix.qml
+++ b/resources/Matrix/matrix.qml
@@ -69,9 +69,6 @@ Rectangle {
         property var drops: []
         property bool fadeout: false
 
-        renderTarget: Canvas.FramebufferObject
-        renderStrategy: Canvas.Cooperative
-
         onPaint: {
             var ctx = getContext("2d");
 


### PR DESCRIPTION
It would seem that the new hardware acceleration options on the QML Canvas introduced the memory leak we were seeing with @skarbat 's automation script.

## Setups:

 - CKC + 22nd rc + qmlmatrix v4.0: NO kernel crashes using his test_ssaver_loop.sh, but showing mem leak
![plot_gpu_mem 1](https://user-images.githubusercontent.com/3577547/41787873-aaed96fc-7641-11e8-997b-87d9591a43d5.png)

 - CKC + 17th devel + qmlmatrix v1 + audio_pwm_mode=1: NO kernel crashes using his test_ssaver_loop.sh and no mem leak
![plot_gpu_mem](https://user-images.githubusercontent.com/3577547/41787924-c3a4a8ac-7641-11e8-9971-676f16bfe249.png)


## Requires:

https://github.com/KanoComputing/kano-settings/pull/511
https://github.com/KanoComputing/kano-updater/pull/324